### PR TITLE
fix CI print used images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - ./mvnw clean verify -Pe2e
 
 after_script:
-  - minikube ssh "docker images --no-trunc=true"
+  - docker images --no-trunc=true
 
 env:
   global:


### PR DESCRIPTION
#27 didn't print anything because minikube uses `none` driver. https://travis-ci.org/jaegertracing/jaeger-kubernetes/builds/261738956#L1526 