### PR TITLE
Add missing labels to ES template

### DIFF
--- a/production-elasticsearch/jaeger-production-template-with-elasticsearch.yml
+++ b/production-elasticsearch/jaeger-production-template-with-elasticsearch.yml
@@ -25,9 +25,10 @@ items:
     template:
       metadata:
         labels:
-          app: elasticsearch
+          app: jaeger
           type: databases
           availability: restricted
+          jaeger-infra: elasticsearch-statefulset
       spec:
         containers:
           - name: elasticsearch
@@ -48,6 +49,9 @@ items:
   kind: Service
   metadata:
     name: elasticsearch
+    labels:
+      app: jaeger
+      jaeger-infra: elasticsearch-service
   spec:
     clusterIP: None
     selector:


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Align with cassandra template. This also makes possible to remove all by `kubectl delete all,daemonset -l jaeger-infra`