### PR TITLE
Elasticsearch deploy two replicas

### DIFF
--- a/jaegertracing-kubernetes-deployment-itest/src/main/java/io/jaegertracing/kubernetes/deployment/BaseETest.java
+++ b/jaegertracing-kubernetes-deployment-itest/src/main/java/io/jaegertracing/kubernetes/deployment/BaseETest.java
@@ -55,25 +55,25 @@ public class BaseETest {
   private static final String COLLECTOR_SERVICE_NAME = "jaeger-collector";
   private static final String ZIPKIN_SERVICE_NAME = "zipkin";
 
-  private OkHttpClient okHttpClient = new OkHttpClient.Builder()
+  protected OkHttpClient okHttpClient = new OkHttpClient.Builder()
       .build();
 
   @Named(QUERY_SERVICE_NAME)
   @PortForward
   @ArquillianResource
-  private URL queryUrl;
+  protected URL queryUrl;
 
   @Port(14268)
   @Named(COLLECTOR_SERVICE_NAME)
   @PortForward
   @ArquillianResource
-  private URL collectorUrl;
+  protected URL collectorUrl;
 
   @Port(9411)
   @Named(ZIPKIN_SERVICE_NAME)
   @PortForward
   @ArquillianResource
-  private URL zipkinUrl;
+  protected URL zipkinUrl;
 
   @Test
   public void testUiResponds() throws IOException, InterruptedException {

--- a/production-elasticsearch/jaeger-production-template-with-elasticsearch.yml
+++ b/production-elasticsearch/jaeger-production-template-with-elasticsearch.yml
@@ -19,16 +19,17 @@ items:
   kind: StatefulSet
   metadata:
     name: elasticsearch
+    labels:
+      app: jaeger
+      jaeger-infra: elasticsearch-statefulset
   spec:
     serviceName: elasticsearch
-    replicas: 1
+    replicas: 2
     template:
       metadata:
         labels:
-          app: jaeger
-          type: databases
-          availability: restricted
-          jaeger-infra: elasticsearch-statefulset
+          app: jaeger-elasticsearch
+          jaeger-infra: elasticsearch-replica
       spec:
         containers:
           - name: elasticsearch
@@ -39,6 +40,7 @@ items:
             args:
               - "-Ehttp.host=0.0.0.0"
               - "-Etransport.host=127.0.0.1"
+              - "-Ecluster.name=foobar"
             volumeMounts:
               - name: data
                 mountPath: /data
@@ -55,10 +57,12 @@ items:
   spec:
     clusterIP: None
     selector:
-      app: elasticsearch
+      app: jaeger-elasticsearch
     ports:
     - port: 9200
       name: elasticsearch
+    - port: 9300
+      name: transport
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:

--- a/production-elasticsearch/src/test/java/io/jaegertracing/kubernetes/ProductionETest.java
+++ b/production-elasticsearch/src/test/java/io/jaegertracing/kubernetes/ProductionETest.java
@@ -31,7 +31,7 @@ public class ProductionETest extends BaseETest {
   /**
    * We need to initialize ES storage, before we proceed to tests for two reasons:
    * 1. sometimes first span is not stored
-   * 2. jaeger-query returns 500 is ES storage is empty (without indices)
+   * 2. jaeger-query returns 500 is ES storage is empty (without indices) https://github.com/jaegertracing/jaeger/issues/464
    */
   @Before
   public void before() {


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

This fixes 
* #44 which is related to https://github.com/jaegertracing/jaeger/issues/464
* introduced issue with selector from https://github.com/jaegertracing/jaeger-kubernetes/pull/45 (yes it broke template :/)