### PR TITLE
Remove executable as an argument to containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ Assuming that your application is named `myapp` and the image is for it is `myna
           - containerPort: 5778
             protocol: TCP
           command:
-          - "/go/bin/agent-linux"
           - "--collector.host-port=jaeger-collector.jaeger-infra.svc:14267"
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ Assuming that your application is named `myapp` and the image is for it is `myna
             protocol: UDP
           - containerPort: 5778
             protocol: TCP
-          command:
-          - "--collector.host-port=jaeger-collector.jaeger-infra.svc:14267"
+          args: ["--collector.host-port=jaeger-collector.jaeger-infra.svc:14267"]
 ```
 
 The Jaeger Agent will then be available to your application at `localhost:5775`/`localhost:6831`/`localhost:6832`/`localhost:5778`.

--- a/jaeger-production-template.yml
+++ b/jaeger-production-template.yml
@@ -35,8 +35,7 @@ items:
         containers:
         - image: jaegertracing/jaeger-collector:1.6.0
           name: jaeger-collector
-          command:
-            - "--config-file=/conf/collector.yaml"
+          args: ["--config-file=/conf/collector.yaml"]
           ports:
           - containerPort: 14267
             protocol: TCP
@@ -120,8 +119,7 @@ items:
         containers:
         - image: jaegertracing/jaeger-query:1.6.0
           name: jaeger-query
-          command:
-            - "--config-file=/conf/query.yaml"
+          args: ["--config-file=/conf/query.yaml"]
           ports:
           - containerPort: 16686
             protocol: TCP
@@ -178,8 +176,7 @@ items:
         containers:
         - name: agent-instance
           image: jaegertracing/jaeger-agent:1.6.0
-          command:
-          - "--config-file=/conf/agent.yaml"
+          args: ["--config-file=/conf/agent.yaml"]
           volumeMounts:
           - name: jaeger-configuration-volume
             mountPath: /conf

--- a/jaeger-production-template.yml
+++ b/jaeger-production-template.yml
@@ -33,7 +33,7 @@ items:
           jaeger-infra: collector-pod
       spec:
         containers:
-        - image: jaegertracing/jaeger-collector:1.5.0
+        - image: jaegertracing/jaeger-collector:1.6.0
           name: jaeger-collector
           command:
             - "--config-file=/conf/collector.yaml"
@@ -118,7 +118,7 @@ items:
           jaeger-infra: query-pod
       spec:
         containers:
-        - image: jaegertracing/jaeger-query:1.5.0
+        - image: jaegertracing/jaeger-query:1.6.0
           name: jaeger-query
           command:
             - "--config-file=/conf/query.yaml"
@@ -177,7 +177,7 @@ items:
       spec:
         containers:
         - name: agent-instance
-          image: jaegertracing/jaeger-agent:1.5.0
+          image: jaegertracing/jaeger-agent:1.6.0
           command:
           - "--config-file=/conf/agent.yaml"
           volumeMounts:

--- a/jaeger-production-template.yml
+++ b/jaeger-production-template.yml
@@ -36,7 +36,6 @@ items:
         - image: jaegertracing/jaeger-collector:1.5.0
           name: jaeger-collector
           command:
-            - "/go/bin/collector-linux"
             - "--config-file=/conf/collector.yaml"
           ports:
           - containerPort: 14267
@@ -122,7 +121,6 @@ items:
         - image: jaegertracing/jaeger-query:1.5.0
           name: jaeger-query
           command:
-            - "/go/bin/query-linux"
             - "--config-file=/conf/query.yaml"
           ports:
           - containerPort: 16686
@@ -181,7 +179,6 @@ items:
         - name: agent-instance
           image: jaegertracing/jaeger-agent:1.5.0
           command:
-          - "/go/bin/agent-linux"
           - "--config-file=/conf/agent.yaml"
           volumeMounts:
           - name: jaeger-configuration-volume

--- a/production-elasticsearch/configmap.yml
+++ b/production-elasticsearch/configmap.yml
@@ -34,8 +34,6 @@ data:
       server-urls: http://elasticsearch:9200
       username: elastic
       password: changeme
-    query:
-      static-files: /go/jaeger-ui/
   agent: |
     collector:
       host-port: "jaeger-collector:14267"

--- a/production/cassandra.yml
+++ b/production/cassandra.yml
@@ -120,7 +120,7 @@ items:
       spec:
         containers:
         - name: jaeger-cassandra-schema
-          image: jaegertracing/jaeger-cassandra-schema:1.5.0
+          image: jaegertracing/jaeger-cassandra-schema:1.6.0
           env:
             - name: MODE
               value: "prod"

--- a/production/configmap.yml
+++ b/production/configmap.yml
@@ -32,8 +32,6 @@ data:
     cassandra:
       servers: cassandra
       keyspace: jaeger_v1_dc1
-    query:
-      static-files: /go/jaeger-ui/
   agent: |
     collector:
       host-port: "jaeger-collector:14267"


### PR DESCRIPTION
Jaeger containers were changed to no longer require the path
to the executable as an argument to docker run, so remove all
instances of executable path

Signed-off-by: Zachary DiCesare zachary.v.dicesare@gmail.com