### PR TITLE
Add HTTP Port 5778

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,17 +113,18 @@ Assuming that your application is named `myapp` and the image is for it is `myna
           ports:
           - containerPort: 5775
             protocol: UDP
-          - containerPort: 5778
           - containerPort: 6831
             protocol: UDP
           - containerPort: 6832
             protocol: UDP
+          - containerPort: 5778
+            protocol: TCP
           command:
           - "/go/bin/agent-linux"
           - "--collector.host-port=jaeger-collector.jaeger-infra.svc:14267"
 ```
 
-The Jaeger Agent will then be available to your application at `localhost:5775`/`localhost:6831`/`localhost:6832`.
+The Jaeger Agent will then be available to your application at `localhost:5775`/`localhost:6831`/`localhost:6832`/`localhost:5778`.
 In most cases, you don't need to specify a hostname or port to your Jaeger Tracer, as it will default to the right
 values already.
 

--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 The Jaeger Authors
+# Copyright 2017-2018 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -45,6 +45,8 @@ items:
                   protocol: UDP
                 - containerPort: 6832
                   protocol: UDP
+                - containerPort: 5778
+                  protocol: TCP
                 - containerPort: 16686
                   protocol: TCP
                 - containerPort: 9411
@@ -115,6 +117,10 @@ items:
       port: 6832
       protocol: UDP
       targetPort: 6832
+    - name: agent-configs
+      port: 5778
+      protocol: TCP
+      targetPort: 5778
     clusterIP: None
     selector:
       jaeger-infra: jaeger-pod

--- a/jaeger-production-template.yml
+++ b/jaeger-production-template.yml
@@ -193,6 +193,8 @@ items:
             protocol: UDP
           - containerPort: 6832
             protocol: UDP
+          - containerPort: 5778
+            protocol: TCP
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         volumes:


### PR DESCRIPTION
https://www.jaegertracing.io/docs/deployment/#agent

```
$ grep -r 5775 *
all-in-one/jaeger-all-in-one-template.yml:                - containerPort: 5775
all-in-one/jaeger-all-in-one-template.yml:      port: 5775
all-in-one/jaeger-all-in-one-template.yml:      targetPort: 5775
jaeger-production-template.yml:          - containerPort: 5775
README.md:          - containerPort: 5775
README.md:The Jaeger Agent will then be available to your application at `localhost:5775`/`localhost:6831`/`localhost:6832`/`localhost:5778`.
$ grep -r 5778 *
all-in-one/jaeger-all-in-one-template.yml:                - containerPort: 5778
all-in-one/jaeger-all-in-one-template.yml:      port: 5778
all-in-one/jaeger-all-in-one-template.yml:      targetPort: 5778
jaeger-production-template.yml:          - containerPort: 5778
README.md:          - containerPort: 5778
README.md:The Jaeger Agent will then be available to your application at `localhost:5775`/`localhost:6831`/`localhost:6832`/`localhost:5778`.
```

Signed-off-by: Victor Lei <klei22@bloomberg.net>