### PR TITLE
Add readinessProbe using healthcheck port

### DIFF
--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -54,7 +54,7 @@ items:
               readinessProbe:
                 httpGet:
                   path: "/"
-                  port: 16686
+                  port: 14269
                 initialDelaySeconds: 5
 - apiVersion: v1
   kind: Service

--- a/jaeger-production-template.yml
+++ b/jaeger-production-template.yml
@@ -43,6 +43,10 @@ items:
             protocol: TCP
           - containerPort: 9411
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 14269
           volumeMounts:
           - name: jaeger-configuration-volume
             mountPath: /conf
@@ -126,7 +130,7 @@ items:
           readinessProbe:
             httpGet:
               path: "/"
-              port: 16686
+              port: 16687
           volumeMounts:
           - name: jaeger-configuration-volume
             mountPath: /conf


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Jaeger should use health check port for readinessProbe 
- Resolves: #86 

## Short description of the changes
- Add readinessProbe in Collector. 
- Result from `kubectl describe`
```
// collector
Readiness:      http-get http://:14269/ delay=0s timeout=1s period=10s #success=1 #failure=3
// query
Readiness:      http-get http://:16687/ delay=0s timeout=1s period=10s #success=1 #failure=3
// standalone
Readiness:      http-get http://:14269/ delay=5s timeout=1s period=10s #success=1 #failure=3
```
