### PR TITLE
Add prometheus scrape annotations

### DIFF
--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -31,6 +31,9 @@ items:
         labels:
           app: jaeger
           jaeger-infra: jaeger-pod
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "16686"
       spec:
           containers:
           -   env:

--- a/jaeger-production-template.yml
+++ b/jaeger-production-template.yml
@@ -31,6 +31,9 @@ items:
         labels:
           app: jaeger
           jaeger-infra: collector-pod
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "14268"
       spec:
         containers:
         - image: jaegertracing/jaeger-collector:1.6.0
@@ -119,6 +122,9 @@ items:
         labels:
           app: jaeger
           jaeger-infra: query-pod
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "16686"
       spec:
         containers:
         - image: jaegertracing/jaeger-query:1.6.0
@@ -176,6 +182,9 @@ items:
         labels:
           app: jaeger
           jaeger-infra: agent-instance
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "5778"
       spec:
         containers:
         - name: agent-instance


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Enable jaeger backend metrics to be automatically scraped by Prometheus.

## Short description of the changes
Add annotation (scrape = true and relevant port) to enable prometheus to discover the jaeger backend metrics.
