### PR TITLE
Explicit env var for CSQLSH_HOST in k8s resource

### DIFF
--- a/production/cassandra.yml
+++ b/production/cassandra.yml
@@ -126,4 +126,6 @@ items:
               value: "prod"
             - name: DATACENTER
               value: "dc1"
+            - name: CQLSH_HOST
+              value: "cassandra"
         restartPolicy: OnFailure


### PR DESCRIPTION
Making CSQLSH_HOST explicit makes it easier to understand how the schema job discovers the cassandra cluster. It also provide a helpful clue for users that might be deploying cassandra under a name other than "cassandra", which is the default value hard-coded into the schema job's docker image.

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-

## Short description of the changes
-
