### PR TITLE
Fix a link formatting problem in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Please see [CONTRIBUTING.md](https://github.com/jaegertracing/jaeger-kubernetes/blob/master/CONTRIBUTING.md)
 
 ## Development setup
-This template uses an in-memory storage with a limited functionality for local testing and development. The image used defaults to the latest version (released)[https://github.com/jaegertracing/jaeger/releases].
+This template uses an in-memory storage with a limited functionality for local testing and development. The image used defaults to the latest version [released](https://github.com/jaegertracing/jaeger/releases).
 Do not use this template in production environments. Note that functionality may differ from the pinned docker versions for production.
 
 Install everything in the current namespace:


### PR DESCRIPTION
## Which problem is this PR solving?
- There's something that seems like a Markdown link in the README, except it's backwards.

## Short description of the changes
- Makes it a link.