### PR TITLE
Updated copyright years to include 2019

### DIFF
--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/jaeger-production-template.yml
+++ b/jaeger-production-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/production-elasticsearch/configmap.yml
+++ b/production-elasticsearch/configmap.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/production-elasticsearch/elasticsearch.yml
+++ b/production-elasticsearch/elasticsearch.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/production/cassandra.yml
+++ b/production/cassandra.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/production/configmap.yml
+++ b/production/configmap.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Without this change, PRs like #113 will fail during the `license:check` goal.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
