### PR TITLE
Update all-in-one-template in accordance with k8s 1.16

### DIFF
--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2019 The Jaeger Authors
+# Copyright 2017-2020 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: List
 items:
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: jaeger
@@ -25,6 +25,9 @@ items:
       app.kubernetes.io/component: all-in-one
   spec:
     replicas: 1
+    selector:
+      matchLabels:
+        app: jaeger
     strategy:
       type: Recreate
     template:
@@ -76,6 +79,9 @@ items:
         protocol: TCP
         targetPort: 16686
     selector:
+      matchLabels:
+        app: jaeger-query
+    selector:
       app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
     type: LoadBalancer
@@ -101,6 +107,9 @@ items:
       port: 9411
       protocol: TCP
       targetPort: 9411
+    selector:
+      matchLabels:
+        app: jaeger-collector
     selector:
       app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
@@ -133,6 +142,9 @@ items:
       targetPort: 5778
     clusterIP: None
     selector:
+      matchLabels:
+        app: jaeger-agent
+    selector:
       app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
 - apiVersion: v1
@@ -151,6 +163,8 @@ items:
       targetPort: 9411
     clusterIP: None
     selector:
+      matchLabels:
+        app: zipkin
+    selector:
       app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
-

--- a/travis/install-start-minikube.sh
+++ b/travis/install-start-minikube.sh
@@ -13,8 +13,8 @@
 # the License.
 #
 
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube
-curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.5.2/minikube-linux-amd64 && chmod +x minikube
+curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.16.2/bin/linux/amd64/kubectl && chmod +x kubectl
 
 export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false

--- a/travis/install-start-minikube.sh
+++ b/travis/install-start-minikube.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2020 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Adds the changes mentioned in the https://github.com/jaegertracing/jaeger-kubernetes/issues/120 due to the related PR's delay

## Short description of the changes
Refactoring of the `jaeger-all-in-one-template.yml` according to changed defined in [ changelog k8s 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)
