### PR TITLE
jaeger-cassandra-schema-job: unset activeDeadlineSeconds

### DIFF
--- a/production/cassandra.yml
+++ b/production/cassandra.yml
@@ -122,7 +122,6 @@ items:
       app.kubernetes.io/component: storage-backend
       app.kubernetes.io/part-of: jaeger
   spec:
-    activeDeadlineSeconds: 120
     template:
       metadata:
         name: cassandra-schema

--- a/production/cassandra.yml
+++ b/production/cassandra.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2019 The Jaeger Authors
+# Copyright 2017-2020 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/production/cassandra.yml
+++ b/production/cassandra.yml
@@ -122,10 +122,12 @@ items:
       app.kubernetes.io/component: storage-backend
       app.kubernetes.io/part-of: jaeger
   spec:
+    activeDeadlineSeconds: 86400
     template:
       metadata:
         name: cassandra-schema
       spec:
+        activeDeadlineSeconds: 320
         containers:
         - name: jaeger-cassandra-schema
           image: jaegertracing/jaeger-cassandra-schema:1.6.0


### PR DESCRIPTION
Please also see commit message.

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Context: https://github.com/jaegertracing/jaeger-kubernetes/issues/32
- `jaeger-cassandra-schema-job` can transition into a permanent failure state that requires human intervention, although the underlying problem is most often a transient one.  


## Short description of the changes
- Do not apply a deadline, simply keep trying to create the schema until it succeeds.
- This is a follow-up patch after my comment here: https://github.com/jaegertracing/jaeger-kubernetes/issues/32#issuecomment-573032045


Feedback welcome. What do you think? Any negative implications in this that we do not want to have?